### PR TITLE
feat: add `--publish` flag to release_on_crate_version_change.ts

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -183,3 +183,7 @@ export class GitTags {
     return previousVersion?.name;
   }
 }
+
+export function containsVersion(text: string) {
+  return /[0-9]+\.[0-9]+\.[0-9]+/.test(text);
+}

--- a/repo.ts
+++ b/repo.ts
@@ -212,6 +212,16 @@ export class Repo {
     );
   }
 
+  /** Gets the commit message for the current commit. */
+  async gitCurrentCommitMessage() {
+    return (await this.runCommand([
+      "git",
+      "log",
+      "-1",
+      `--pretty=%B`,
+    ])).trim();
+  }
+
   async getGitTags() {
     return new GitTags((await this.runCommand(["git", "tag"])).split(/\r?\n/));
   }

--- a/tasks/release_on_crate_version_change.ts
+++ b/tasks/release_on_crate_version_change.ts
@@ -11,6 +11,21 @@
 // Note: this will detect whether to add a `v` prefix or not based on the most recent
 // version tag.
 //
+// # CLI Arguments
+//
+// If you have multiple crates, then you will need to provide the crate name
+// to use to determine the tag name as an argument to the script.
+//
+// ```bash
+// deno run -A --no-check <url-to-this-module> <crate-name-goes-here>
+// ```
+//
+// If you want to publish to crates.io, provide a `--publish` flag:
+//
+// ```bash
+// deno run -A --no-check <url-to-this-module> --publish
+// ```
+//
 // # Example Use
 //
 // ```yml
@@ -22,21 +37,21 @@
 //     github.ref == 'refs/heads/main'
 //    run: deno run -A --no-check <url-to-this-module>
 // ```
-//
-// If you have multiple crates, then you will need to provide the crate name
-// to use to determine the tag name as an argument to the script.
-//
-// ```bash
-// deno run -A --no-check <url-to-this-module> <crate-name-goes-here>
-// ```
 
-import { path, Repo } from "../mod.ts";
+import { containsVersion, path, Repo } from "../mod.ts";
 import { createOctoKit, getGitHubRepository } from "../github_actions.ts";
 
+const cliArgs = getCliArgs();
 const cwd = path.resolve(".");
 const repoName = path.basename(cwd);
 const repo = await Repo.load(repoName, cwd);
 const octokit = createOctoKit();
+
+// only run this for commits that contain a version number in the commit message
+if (!containsVersion(await repo.gitCurrentCommitMessage())) {
+  console.log("Exiting: No version found in commit name.");
+  Deno.exit();
+}
 
 // safeguard for in case if someone doesn't run this on the main branch
 await repo.assertCurrentBranch("main");
@@ -49,6 +64,13 @@ const tagName = repoTags.getTagNameForVersion(mainCrate.version);
 if (repoTags.has(tagName)) {
   console.log(`Tag ${tagName} already exists.`);
 } else {
+  if (cliArgs.publish) {
+    console.log(`Publishing ${tagName}...`);
+    for (const crate of repo.getCratesPublishOrder()) {
+      await crate.publish();
+    }
+  }
+
   console.log(`Tagging ${tagName}...`);
   await repo.gitTag(tagName);
   await repo.gitPush("origin", tagName);
@@ -68,11 +90,30 @@ if (repoTags.has(tagName)) {
 function getMainCrate() {
   if (repo.crates.length === 1) {
     return repo.crates[0];
-  } else if (Deno.args.length >= 1) {
-    return repo.getCrate(Deno.args[0]);
+  } else if (cliArgs.crate != null) {
+    return repo.getCrate(cliArgs.crate);
   } else {
     throw new Error(
       `You must supply a crate name CLI argument.\n${repo.crateNamesText()}`,
     );
   }
+}
+
+function getCliArgs() {
+  // very basic arg parsing... should improve later
+  let crate: string | undefined;
+  let publish = false;
+  for (const arg of Deno.args) {
+    if (arg === "--publish") {
+      publish = true;
+    } else if (crate == null) {
+      crate = arg;
+    } else {
+      throw new Error(`Invalid arguments: ${Deno.args.join(" ")}`);
+    }
+  }
+  return {
+    publish,
+    crate,
+  };
 }


### PR DESCRIPTION
I just realized there's no reason to run the CI again for a publish workflow. With this flag the following will occur:

1. Cargo publish of all the crates in the repo if they haven't been published.
2. Tag.
3. Release with version notes.

This also makes it so this script only runs on commits that includes a version number in it. This will prevent consecutive commits landing to main and causing a publish.