### PR TITLE
fix: release notes - do not include version commit that has text after the version

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -114,7 +114,7 @@ export class GitLogOutput {
       .map((line) => line.replace(/^[a-f0-9]+ /i, "").trim())
       .filter((l) => {
         // don't include version commits
-        if (/^v?[0-9]+\.[0-9]+\.[0-9]+$/.test(l)) {
+        if (/^v?[0-9]+\.[0-9]+\.[0-9]+/.test(l)) {
           return false;
         }
 


### PR DESCRIPTION
Everything went well in the deno_ast release, but it included the version commit in the release notes because it had the PR in it:

```
0.12.1 (#74)
```