### PR TITLE
fix(release_on_crate_version_change): use tag name for release name

### DIFF
--- a/tasks/release_on_crate_version_change.ts
+++ b/tasks/release_on_crate_version_change.ts
@@ -87,6 +87,7 @@ if (repoTags.has(tagName)) {
     await octokit.request(`POST /repos/{owner}/{repo}/releases`, {
       ...getGitHubRepository(),
       tag_name: tagName,
+      name: tagName,
       body: gitLog.formatForReleaseMarkdown(),
       draft: false,
     });


### PR DESCRIPTION
Did a release and it had the commit message in the release name instead of the version.