### PR TITLE
fix: actually sort release markdown

### DIFF
--- a/helpers.ts
+++ b/helpers.ts
@@ -123,8 +123,8 @@ export class GitLogOutput {
           .some((prefix) => l.message.startsWith(prefix)) &&
           l.message.length > 0;
       })
-      .sort()
       .map((line) => `- ${line.message}`)
+      .sort()
       .join("\n");
   }
 }


### PR DESCRIPTION
I introduced this bug recently because it went from storing strings to objects, which introduced the bug because now it was sorting objects.