### PR TITLE
fix: smarter crate publish order

### DIFF
--- a/cargo.ts
+++ b/cargo.ts
@@ -23,6 +23,7 @@ export interface CargoDependencyMetadata {
   name: string;
   /** Version requrement (ex. ^0.1.0) */
   req: string;
+  kind: "dev" | null;
 }
 
 export function getCargoMetadata(directory: string) {

--- a/crate.ts
+++ b/crate.ts
@@ -174,7 +174,7 @@ export class Crate {
     while (stack.length > 0) {
       const item = stack.pop()!;
       const crate = item.crate;
-      if (item.kind !== "dev" && !crates.has(crate.name)) {
+      if (!item.isDev && !crates.has(crate.name)) {
         crates.set(crate.name, crate);
         stack.push(...crate.immediateDependenciesInRepo());
       }
@@ -189,7 +189,7 @@ export class Crate {
       const crate = this.repo.crates.find((c) => c.name === dependency.name);
       if (crate != null) {
         dependencies.push({
-          kind: dependency.kind,
+          isDev: dependency.kind === "dev",
           crate,
         });
       }

--- a/crate.ts
+++ b/crate.ts
@@ -166,16 +166,17 @@ export class Crate {
     });
   }
 
-  /** Gets all the descendant dependencies in the repository. */
-  descendantDependenciesInRepo() {
+  /** Gets all the descendant non dev dependencies in the repository. */
+  descendantNonDevDependenciesInRepo() {
     // try to maintain publish order.
     const crates = new Map<string, Crate>();
     const stack = [...this.immediateDependenciesInRepo()];
     while (stack.length > 0) {
       const item = stack.pop()!;
-      if (!crates.has(item.name)) {
-        crates.set(item.name, item);
-        stack.push(...item.immediateDependenciesInRepo());
+      const crate = item.crate;
+      if (item.kind !== "dev" && !crates.has(crate.name)) {
+        crates.set(crate.name, crate);
+        stack.push(...crate.immediateDependenciesInRepo());
       }
     }
     return Array.from(crates.values());
@@ -187,7 +188,10 @@ export class Crate {
     for (const dependency of this.#pkg.dependencies) {
       const crate = this.repo.crates.find((c) => c.name === dependency.name);
       if (crate != null) {
-        dependencies.push(crate);
+        dependencies.push({
+          kind: dependency.kind,
+          crate,
+        });
       }
     }
     return dependencies;

--- a/repo.ts
+++ b/repo.ts
@@ -284,7 +284,7 @@ export function getCratesPublishOrder(crates: Iterable<Crate>) {
   while (pendingCrates.length > 0) {
     for (let i = pendingCrates.length - 1; i >= 0; i--) {
       const crate = pendingCrates[i];
-      const hasPendingDependency = crate.descendantDependenciesInRepo()
+      const hasPendingDependency = crate.descendantNonDevDependenciesInRepo()
         .some((c) => pendingCrates.includes(c));
       if (!hasPendingDependency) {
         sortedCrates.push(crate);

--- a/repo.ts
+++ b/repo.ts
@@ -1,7 +1,7 @@
 /// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
 
 import { CargoPackageMetadata, getCargoMetadata } from "./cargo.ts";
-import { Crate } from "./crate.ts";
+import { Crate, CrateDep } from "./crate.ts";
 import { $, dax } from "./deps.ts";
 import { GitLogOutput, GitTags } from "./helpers.ts";
 
@@ -278,20 +278,32 @@ export class Repo {
 }
 
 export function getCratesPublishOrder(crates: Iterable<Crate>) {
-  const pendingCrates = [...crates];
-  const sortedCrates = [];
+  const sortedCrates: ({ crate: Crate; deps: CrateDep[] })[] = [];
 
-  while (pendingCrates.length > 0) {
-    for (let i = pendingCrates.length - 1; i >= 0; i--) {
-      const crate = pendingCrates[i];
-      const hasPendingDependency = crate.descendantNonDevDependenciesInRepo()
-        .some((c) => pendingCrates.includes(c));
-      if (!hasPendingDependency) {
-        sortedCrates.push(crate);
-        pendingCrates.splice(i, 1);
-      }
-    }
+  for (const crate of crates) {
+    const deps = crate.immediateDependenciesInRepo();
+    const insertPos = getInsertPosition(crate, deps);
+    sortedCrates.splice(insertPos, 0, { crate, deps });
   }
 
-  return sortedCrates;
+  return sortedCrates.map((i) => i.crate);
+
+  function getInsertPosition(crate: Crate, crateDeps: CrateDep[]) {
+    for (let i = 0; i < sortedCrates.length; i++) {
+      const item = sortedCrates[i];
+      const crateItemDep = item.deps.find((d) => d.crate.name === crate.name);
+      if (crateItemDep != null) {
+        const depB = crateDeps.find((d) => d.crate.name === item.crate.name);
+        if (crateItemDep.isDev === depB?.isDev) {
+          throw new Error(
+            `Circular dependency found between ${crate.name} and ${item.crate.name}`,
+          );
+        }
+        if (!crateItemDep.isDev) {
+          return i;
+        }
+      }
+    }
+    return sortedCrates.length;
+  }
 }

--- a/repo.ts
+++ b/repo.ts
@@ -299,7 +299,7 @@ export function getCratesPublishOrder(crates: Iterable<Crate>) {
             `Circular dependency found between ${crate.name} and ${item.crate.name}`,
           );
         }
-        if (!crateItemDep.isDev) {
+        if (depB == null || !crateItemDep.isDev) {
           return i;
         }
       }


### PR DESCRIPTION
This now takes into account circular dependencies where one could be a dev dependency.