### PR TITLE
feat: support repos with versions for crates in same repo in individual cargo.toml files

### DIFF
--- a/crate.ts
+++ b/crate.ts
@@ -96,6 +96,12 @@ export class Crate {
       const newText = originalText.replace(findRegex, `$1"${version}"`);
       if (originalText !== newText) {
         await Deno.writeTextFile(rootpath, newText);
+      } else {
+        // in this case, the repo does not keep the version
+        // inside the root cargo.toml file
+        for (const crate of this.repo.crates) {
+          await crate.setDependencyVersion(this.name, version);
+        }
       }
     }
 


### PR DESCRIPTION
Ammendment to #34. I was upgrading some crates and it was too much work to upgrade them all to use workspace members atm.