### PR TITLE
refactor(): prepare deno std for `noUncheckedIndexedAccess`

### DIFF
--- a/github_actions.ts
+++ b/github_actions.ts
@@ -2,9 +2,15 @@
 
 import { Octokit } from "npm:octokit@^3.1";
 
-export function getGitHubRepository() {
+export function getGitHubRepository(): { owner: string, repo: string } {
   const repoEnvVar = getEnvVarOrThrow("GITHUB_REPOSITORY");
   const [owner, repo] = repoEnvVar.split("/");
+  if (repo === undefined) {
+    throw new Error(
+      `Environment variable GITHUB_REPOSITORY ` +
+        `must be formatted as "{owner}/{repo}".`,
+    );
+  }
   return {
     owner,
     repo,


### PR DESCRIPTION
This is part of the effort to rollout the `noUncheckedIndexedAccess` config for deno std https://github.com/denoland/deno_std/issues/4040

The function `getGitHubRepository` currently has the implied type 
```typescript
() => { owner: string | undefined, repo: string  | undefined }
```
It feels cleaner to solve the undefined checking here rather than downstream in deno std `_tools/`, however if this change isn't acceptable then we can wrap the function in deno std.

Tagging @dsherret since you seem to be a primary maintainer of this repo.
